### PR TITLE
Add error handling for AppVeyor and globally

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: node_js
 node_js:
   - node
-  - 4.4.5
+  - 5.11.1
 
 script:
   - npm run build

--- a/src/hubot-slack.d.ts
+++ b/src/hubot-slack.d.ts
@@ -1,21 +1,55 @@
 declare module "hubot-slack" {
   import { IAdapter } from 'hubot';
 
+  // see https://api.slack.com/docs/attachments
+  // also https://api.slack.com/docs/formatting/builder
   interface IAttachment {
     fallback: string;
+    color: string;
+    pretext?: string;
+    
+    author_name?: string;
+    author_link?: string;
+    author_icon?: string;
+
     title: string;
     title_link?: string;
-    text: string;
-    color?: string;
+    
+    text?: string;
+
+    fields?: [{
+      title: string;
+      value: string;
+      short: boolean;
+    }];
+
+    image_url?: string;
+    thumb_url?: string;
+
+    footer?: string;
+    footer_icon?: string;
+    
+    ts?: number;
+
+    mrkdwn_in?: string[]
   }
 
   interface ICustomMessage {
+    envelope?: any;
+    room?: string;
+  }
+
+  interface ICustomMessageData {
     channel: string;
-    text: string;
+    message?: ICustomMessage;
+    text?: string;
     attachments?: Array<IAttachment>;
+    username?: string;
+    icon_url?: string;
+    icon_emoji?: string;
   }
 
   interface ISlackAdapter extends IAdapter {
-    customMessage(msg: ICustomMessage): void;
+    customMessage(msg: ICustomMessageData): void;
   }
 }

--- a/src/hubot.d.ts
+++ b/src/hubot.d.ts
@@ -32,7 +32,7 @@ declare module "hubot" {
     (res: IResponse): any;
   }
 
-  interface IRobotBrain {
+  interface IHubotBrain {
     get(key: string): string;
     set(key: string, value: string);
   }
@@ -41,13 +41,28 @@ declare module "hubot" {
 
   }
 
-  interface IRobot {
+  interface IHubotLogger {
+    log(levelStr: string, args: any[]);
+    error(...msg: any[]);
+    emergency(...msg: any[]);
+    alert(...msg: any[]);
+    critical(...msg: any[]);
+    warning(...msg: any[]);
+    notice(...msg: any[]);
+    info(...msg: any[]);
+    debug(...msg: any[]);
+  }
+
+  interface IHubot {
     adapter: IAdapter;
-    brain: IRobotBrain;
+    brain: IHubotBrain;
     router: express.Application;
+    logger: IHubotLogger;
 
     respond(matcher: RegExp, listener: IListener);
     http(url: string): IScopedHttpClient;
     messageRoom(room: string, msg: string);
+    error(handler: (err: Error, res: IResponse) => void)
+    emit(event: string, ...args: any[]): boolean;
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,18 +1,20 @@
 import { install } from 'source-map-support';
 install();
 
-import { IRobot } from 'hubot';
+import { IHubot } from 'hubot';
 
 import HelloScript from './scripts/hello';
 import BuildScript from './scripts/build';
 import DeployScript from './scripts/deploy';
+import ErrorScript from './scripts/error';
 
 import { AppVeyor } from './lib/appveyor';
 import { Config } from './lib/config';
 
-module.exports = (robot: IRobot) => {
-  const appveyor = new AppVeyor(robot.http, Config.appveyor.token, Config.appveyor.account);
+module.exports = (robot: IHubot) => {
+  const appveyor = new AppVeyor(robot.http.bind(robot), Config.appveyor.token, Config.appveyor.account);
 
+  ErrorScript(robot);
   HelloScript(robot);
   BuildScript(robot, appveyor);
   DeployScript(robot, appveyor);

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -6,5 +6,6 @@ export const Config = {
       token: process.env.APPVEYOR_WEBHOOK_TOKEN
     }
   },
-  announce_channel: "#finbot-announce"
+  announce_channel: "#finbot-announce",
+  error_channel: "#finbot-coders"
 }

--- a/src/scripts/error.ts
+++ b/src/scripts/error.ts
@@ -1,0 +1,27 @@
+import { IHubot, IScopedHttpClient, IHttpResponse } from 'hubot';
+import { ISlackAdapter, ICustomMessageData } from 'hubot-slack';
+import { Config } from '../lib/config';
+
+export default (robot: IHubot) => {
+
+  robot.error((err, res) => {
+    robot.logger.error(`Caught unhandled error.`, err);
+
+    const slackAdapter = robot.adapter as ISlackAdapter;
+
+    const customMessage: ICustomMessageData = {
+      channel: Config.error_channel,
+      attachments: [{
+        fallback: `I've just encountered this error: ${err}`,
+        color: '#801515',
+        title: `I've just encountered an error`,
+        text: `\`\`\`\n${err.stack}\n\`\`\``,
+        mrkdwn_in: ['title']
+      }]
+    };
+
+    slackAdapter.customMessage(customMessage);
+
+    if (res) res.reply('Uhh, sorry, I just experienced an error :goberserk:');
+  });
+}

--- a/src/scripts/error.ts
+++ b/src/scripts/error.ts
@@ -16,7 +16,7 @@ export default (robot: IHubot) => {
         color: '#801515',
         title: `I've just encountered an error`,
         text: `\`\`\`\n${err.stack}\n\`\`\``,
-        mrkdwn_in: ['title']
+        mrkdwn_in: ['text']
       }]
     };
 

--- a/src/scripts/hello.ts
+++ b/src/scripts/hello.ts
@@ -1,7 +1,7 @@
-import { IRobot } from 'hubot';
+import { IHubot } from 'hubot';
 
-export default (robot: IRobot) => {
+export default (robot: IHubot) => {
   robot.respond(/hello/i, (res) => {
-    res.reply("Yeah, hello etc");
+    res.reply("Yeah, hello etc...");
   });
 }

--- a/src/test/appveyor.test.ts
+++ b/src/test/appveyor.test.ts
@@ -3,7 +3,7 @@ import * as sinon from 'sinon';
 
 import { MockRobot, MockRobotBrain, MockResponse, MockScopedHttpClient, MockSlackAdapter } from './helpers/mocks';
 import { IHttpClientHandler } from 'hubot';
-import { ICustomMessage } from 'hubot-slack';
+import { ICustomMessageData } from 'hubot-slack';
 import * as express from 'express';
 import { Config } from '../lib/config';
 import { AppVeyor } from '../lib/appveyor';
@@ -52,10 +52,12 @@ test.cb('appveyor > build', (t) => {
   sinon.assert.calledWith(postStub, `{"accountName":"${account}","projectSlug":"${project}"}`);
 
   result.then((data) => {
-    t.is(data.accountName, account);
-    t.is(data.projectSlug, project);
-    t.is(data.version, response.version);
-    t.is(data.link, `https://ci.appveyor.com/project/${account}/${project}/build/${response.version}`);
+    t.is(data.ok, true);
+    t.is(data.statusCode, 200);
+    t.is(data.body.accountName, account);
+    t.is(data.body.projectSlug, project);
+    t.is(data.body.version, response.version);
+    t.is(data.body.link, `https://ci.appveyor.com/project/${account}/${project}/build/${response.version}`);
 
     t.end();
   }).catch(t.end);
@@ -98,7 +100,9 @@ test.cb('appveyor > deploy', (t) => {
   sinon.assert.calledWith(postStub, expectedPostBody);
 
   result.then((data) => {
-    t.is(data.link, `https://ci.appveyor.com/project/${account}/${project}/deployment/${deploymentId}`);
+    t.is(data.ok, true);
+    t.is(data.statusCode, 200);
+    t.is(data.body.link, `https://ci.appveyor.com/project/${account}/${project}/deployment/${deploymentId}`);
 
     t.end();
   }).catch(t.end);

--- a/src/test/error.test.ts
+++ b/src/test/error.test.ts
@@ -1,0 +1,76 @@
+import { test } from 'ava';
+import * as sinon from 'sinon';
+
+import { ICustomMessageData } from 'hubot-slack';
+
+import { MockRobot, MockResponse, MockSlackAdapter, MockHubotLogger } from './helpers/mocks';
+import { Config } from '../lib/config';
+import ErrorScript from '../scripts/error';
+
+test('finbot > catches unhandled errors', (t) => {
+  // arrange
+  const err = new Error('I am an error');
+  const errorChannel = 'my-room';
+
+  Config.error_channel = errorChannel;
+
+  const robot = new MockRobot();
+  const errorStub = sinon.stub(robot, 'error');
+
+  const response = new MockResponse();
+  const replyStub = sinon.stub(response, 'reply');
+
+  errorStub.callsArgWith(0, err, response);
+
+  const slackAdapter = new MockSlackAdapter();
+  const customMessageSpy = sinon.spy(slackAdapter, 'customMessage');
+
+  robot.adapter = slackAdapter;
+
+  const logger = new MockHubotLogger();
+  const errorSpy = sinon.spy(logger, 'error');
+
+  robot.logger = logger;
+
+  // act
+  ErrorScript(robot);
+
+  // assert
+  sinon.assert.calledWith(errorSpy, `Caught unhandled error.`, err);
+  sinon.assert.calledOnce(customMessageSpy);
+
+  const actualCustomMessage: ICustomMessageData = customMessageSpy.getCall(0).args[0];
+  t.is(actualCustomMessage.channel, errorChannel);
+  t.is(actualCustomMessage.attachments.length, 1);
+
+  const attachment = actualCustomMessage.attachments[0];
+  t.is(attachment.fallback, `I've just encountered this error: ${err}`);
+  t.is(attachment.title, "I've just encountered an error");
+  t.is(attachment.text, `\`\`\`\n${err.stack}\n\`\`\``);
+  t.is(attachment.color, '#801515');
+  t.deepEqual(attachment.mrkdwn_in, ['title']);
+
+  sinon.assert.calledWith(replyStub, 'Uhh, sorry, I just experienced an error :goberserk:');
+});
+
+test('finbot > catches unhandled errors > when response is not set', (t) => {
+  // arrange
+  const err = new Error('I am an error');
+
+  const robot = new MockRobot();
+  const errorStub = sinon.stub(robot, 'error');
+
+  const response = new MockResponse();
+  const replySpy = sinon.spy(response, 'reply');
+
+  errorStub.callsArgWith(0, err);
+
+  robot.adapter = new MockSlackAdapter();
+  robot.logger = new MockHubotLogger();
+
+  // act
+  ErrorScript(robot);
+
+  // assert
+  sinon.assert.notCalled(replySpy);
+});

--- a/src/test/error.test.ts
+++ b/src/test/error.test.ts
@@ -48,7 +48,7 @@ test('finbot > catches unhandled errors', (t) => {
   t.is(attachment.title, "I've just encountered an error");
   t.is(attachment.text, `\`\`\`\n${err.stack}\n\`\`\``);
   t.is(attachment.color, '#801515');
-  t.deepEqual(attachment.mrkdwn_in, ['title']);
+  t.deepEqual(attachment.mrkdwn_in, ['text']);
 
   sinon.assert.calledWith(replyStub, 'Uhh, sorry, I just experienced an error :goberserk:');
 });

--- a/src/test/hello.test.ts
+++ b/src/test/hello.test.ts
@@ -16,5 +16,5 @@ test('finbot > says hello', (t) => {
   HelloScript(robot);
 
   t.true(respondStub.calledWith(/hello/i, sinon.match.func));
-  t.true(replyStub.calledWith('Yeah, hello etc'));
+  t.true(replyStub.calledWith('Yeah, hello etc...'));
 });

--- a/src/test/helpers/mocks.ts
+++ b/src/test/helpers/mocks.ts
@@ -1,42 +1,45 @@
-import { IRobot, IAdapter, IRobotBrain, IListener, IResponse, IMessageDetail, IScopedHttpClient, IHttpResponse, IHttpClientHandler } from 'hubot';
-import { ISlackAdapter, ICustomMessage } from 'hubot-slack';
+import * as hubot from 'hubot';
+import { ISlackAdapter, ICustomMessageData } from 'hubot-slack';
 import { Application } from 'express';
 import { IAppVeyor, IBuildResponse, IDeployResponse } from '../../lib/appveyor';
 
-export class MockRobot implements IRobot {
-  public adapter: IAdapter;
-  public brain: IRobotBrain;
+export class MockRobot implements hubot.IHubot {
+  public adapter: hubot.IAdapter;
+  public brain: hubot.IHubotBrain;
   public router: Application;
+  public logger: hubot.IHubotLogger;
 
-  public respond(matcher: RegExp, listener: IListener) { }
+  public respond(matcher: RegExp, listener: hubot.IListener) { }
   public http(url: string) { return null; }
   public messageRoom(room: string, msg: string) { }
+  public error(handler: (err: Error, res: hubot.IResponse) => void) { }
+  public emit(event: string, args: any[]) { return false; }
 }
 
-export class MockResponse implements IResponse {
+export class MockResponse implements hubot.IResponse {
   public match: string[];
-  public message: IMessageDetail;
+  public message: hubot.IMessageDetail;
 
   public reply(msg: string) { }
 }
 
-export class MockScopedHttpClient implements IScopedHttpClient {
+export class MockScopedHttpClient implements hubot.IScopedHttpClient {
   public header(name: string, value: string) {
     return this;
   }
 
   public post(body: string) {
-    return (handler: IHttpClientHandler) => {
+    return (handler: hubot.IHttpClientHandler) => {
       handler(null, { statusCode: 200 }, '');
     };
   }
 }
 
 export class MockSlackAdapter implements ISlackAdapter {
-  public customMessage(msg: ICustomMessage) { return null; }
+  public customMessage(msg: ICustomMessageData) { return null; }
 }
 
-export class MockRobotBrain implements IRobotBrain {
+export class MockRobotBrain implements hubot.IHubotBrain {
   public get(key: string) { return null; }
   public set(key: string, value: string) { }
 }
@@ -45,3 +48,16 @@ export class MockAppVeyor implements IAppVeyor {
   public build(projectSlug) { return null; }
   public deploy(projectSlug, version, environment) { return null; }
 }
+
+export class MockHubotLogger implements hubot.IHubotLogger {
+  public log(levelStr: string, args: any[]) {}
+  public error(msg: any[]) {}
+  public emergency(msg: any[]) {}
+  public alert(msg: any[]) {}
+  public critical(msg: any[]) {}
+  public warning(msg: any[]) {}
+  public notice(msg: any[]) {}
+  public info(msg: any[]) {}
+  public debug(msg: any[]) {}
+}
+


### PR DESCRIPTION
Fixes #5 

Handles errors using the [hubot error handler](https://hubot.github.com/docs/scripting/#error-handling).
Handles non-200 AppVeyor responses gracefully.